### PR TITLE
Implement multi-level lead sorting

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -1,0 +1,34 @@
+from sqlalchemy import Table, MetaData, text, Text, Column, ForeignKey, Float, MetaData, orm
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.expression import Executable, ClauseElement
+from sqlalchemy.sql.ddl import DropTable
+from api.models import leads
+import sqlalchemy_views
+
+
+class View(Table):
+    is_view = True
+
+
+class CreateView(sqlalchemy_views.CreateView):
+    def __init__(self, view):
+        super().__init__(view.__view__, view.__definition__)
+
+
+@compiles(DropTable)
+def _compile_drop_table(element, compiler, **kwargs):
+    if hasattr(element.element, 'is_view') and element.element.is_view:
+        return compiler.visit_drop_view(element)
+
+    # cascade seems necessary in case SQLA tries to drop 
+    # the table a view depends on, before dropping the view
+    return compiler.visit_drop_table(element) + ' CASCADE'
+
+class average_leads:
+    __view__ = View(
+        'average_leads', MetaData(),
+         Column('lead_id', None, ForeignKey(leads.c.id), primary_key=True),
+         Column('average_news_value', Float)
+    )
+
+    __definition__ = text('SELECT lead_id, AVG(news_value) as average_news_value  FROM algorithm_tips_app.crowd_ratings GROUP BY lead_id')


### PR DESCRIPTION
Implements a VIEW using the SQL statement ```'SELECT lead_id, AVG(news_value) as average_news_value  FROM algorithm_tips_app.crowd_ratings GROUP BY lead_id'``` 

When the app is first loaded, the API constructs a new VIEW to ensure that it is up-to-date with any changes made to the ```algorithm_tips_app.crowd_ratings``` table. Queries (collection of leads) are first sorted by published date. Leads containing the same published date are then sorted by average crowd rating scores using the VIEW.